### PR TITLE
Fixes #2 error in myst pdf rendering due to author field

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -6,7 +6,7 @@ license: CC-BY-4.0
 thumbnail: ./thumbnail.png
 authors:
   - name: Brenhin Keller
-    github: https://github.com/brenhinkeller
+    github: brenhinkeller
     affiliations:
       - Dartmouth College
 tags:


### PR DESCRIPTION
Convert the author url to the author/project ID as recommended by the rendering error message.